### PR TITLE
change anyForKey visibility.

### DIFF
--- a/Marshal/Object.swift
+++ b/Marshal/Object.swift
@@ -25,7 +25,7 @@ public typealias ObjectArray = [Object]
 
 extension Dictionary where Key: KeyType {
     
-    private func anyForKey(key: Key) throws -> Any {
+    public func anyForKey(key: Key) throws -> Any {
         let pathComponents = key.stringValue.characters.split(".").map(String.init)
         var accumulator: Any = self
         


### PR DESCRIPTION
This allows users to write their own dictionary extraction methods, it needed, without needing to wait for us to implement it in the core.
