### PR TITLE
rename update

### DIFF
--- a/Marshal/UnmarshalUpdating.swift
+++ b/Marshal/UnmarshalUpdating.swift
@@ -15,5 +15,5 @@ import Foundation
 
 
 public protocol UnmarshalUpdating {
-    func update(object: Object)
+    func marshalUpdate(object: Object)
 }

--- a/Marshal/UnmarshalUpdating.swift
+++ b/Marshal/UnmarshalUpdating.swift
@@ -15,5 +15,5 @@ import Foundation
 
 
 public protocol UnmarshalUpdating {
-    func marshalUpdate(object: Object)
+    func marshal(object object: Object)
 }


### PR DESCRIPTION
`update` is such a generic function name. can cause potential problems
with overriding internal things on NSObjects or things. Making the parameter name explicit fixes this.
