### PR TITLE
MarshaledObject

### DIFF
--- a/Marshal.xcodeproj/project.pbxproj
+++ b/Marshal.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		AFBED2531C7E1AAB00622331 /* Marshal.h in Headers */ = {isa = PBXBuildFile; fileRef = AFBED2521C7E1AAB00622331 /* Marshal.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AFBED25A1C7E1AAB00622331 /* Marshal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AFBED24F1C7E1AAB00622331 /* Marshal.framework */; };
 		AFBED25F1C7E1AAB00622331 /* MarshalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED25E1C7E1AAB00622331 /* MarshalTests.swift */; };
-		AFBED26A1C7E1B0500622331 /* Object.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED2691C7E1B0500622331 /* Object.swift */; };
+		AFBED26A1C7E1B0500622331 /* MarshaledObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED2691C7E1B0500622331 /* MarshaledObject.swift */; };
 		AFBED26C1C7E1B3500622331 /* KeyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED26B1C7E1B3500622331 /* KeyType.swift */; };
 		AFBED26E1C7E1CA900622331 /* ValueType.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED26D1C7E1CA900622331 /* ValueType.swift */; };
 		AFBED2701C7E1CF100622331 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBED26F1C7E1CF100622331 /* Error.swift */; };
@@ -46,7 +46,7 @@
 		AFBED2591C7E1AAB00622331 /* MarshalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MarshalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFBED25E1C7E1AAB00622331 /* MarshalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarshalTests.swift; sourceTree = "<group>"; };
 		AFBED2601C7E1AAB00622331 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AFBED2691C7E1B0500622331 /* Object.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Object.swift; sourceTree = "<group>"; };
+		AFBED2691C7E1B0500622331 /* MarshaledObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarshaledObject.swift; sourceTree = "<group>"; };
 		AFBED26B1C7E1B3500622331 /* KeyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyType.swift; sourceTree = "<group>"; };
 		AFBED26D1C7E1CA900622331 /* ValueType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValueType.swift; sourceTree = "<group>"; };
 		AFBED26F1C7E1CF100622331 /* Error.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
@@ -99,7 +99,7 @@
 			children = (
 				AFBED2521C7E1AAB00622331 /* Marshal.h */,
 				AFBED2541C7E1AAB00622331 /* Info.plist */,
-				AFBED2691C7E1B0500622331 /* Object.swift */,
+				AFBED2691C7E1B0500622331 /* MarshaledObject.swift */,
 				AFBED2711C7E1DA800622331 /* Marshaling.swift */,
 				AFBED27B1C7F65BB00622331 /* Unmarshaling.swift */,
 				AFBED27D1C7F699600622331 /* UnmarshalUpdating.swift */,
@@ -243,7 +243,7 @@
 				AFBED27C1C7F65BB00622331 /* Unmarshaling.swift in Sources */,
 				AFBED2761C7E1E5100622331 /* JSON.swift in Sources */,
 				AFBED26E1C7E1CA900622331 /* ValueType.swift in Sources */,
-				AFBED26A1C7E1B0500622331 /* Object.swift in Sources */,
+				AFBED26A1C7E1B0500622331 /* MarshaledObject.swift in Sources */,
 				AFBED26C1C7E1B3500622331 /* KeyType.swift in Sources */,
 				AFBED2741C7E1E0800622331 /* Operators.swift in Sources */,
 			);

--- a/Marshal/JSON.swift
+++ b/Marshal/JSON.swift
@@ -17,7 +17,6 @@ import Foundation
 // MARK: - Types
 
 public typealias JSONObject = MarshaledObject
-public typealias JSONArray = MarshaledArray
 
 
 // MARK: - Parser

--- a/Marshal/JSON.swift
+++ b/Marshal/JSON.swift
@@ -16,8 +16,8 @@ import Foundation
 
 // MARK: - Types
 
-public typealias JSONObject = Object
-public typealias JSONArray = ObjectArray
+public typealias JSONObject = MarshaledObject
+public typealias JSONArray = MarshaledArray
 
 
 // MARK: - Parser

--- a/Marshal/MarshaledObject.swift
+++ b/Marshal/MarshaledObject.swift
@@ -16,9 +16,9 @@ import Foundation
 
 // MARK: - Types
 
-public typealias Object = [String: AnyObject]
+public typealias MarshaledObject = [String: AnyObject]
 
-public typealias ObjectArray = [Object]
+public typealias MarshaledArray = [MarshaledObject]
 
 
 // MARK: - Dictionary Extensions

--- a/Marshal/MarshaledObject.swift
+++ b/Marshal/MarshaledObject.swift
@@ -18,8 +18,6 @@ import Foundation
 
 public typealias MarshaledObject = [String: AnyObject]
 
-public typealias MarshaledArray = [MarshaledObject]
-
 
 // MARK: - Dictionary Extensions
 

--- a/Marshal/Marshaling.swift
+++ b/Marshal/Marshaling.swift
@@ -14,5 +14,5 @@
 import Foundation
 
 public protocol Marshaling {
-    func marshal() -> Object
+    func marshal() -> MarshaledObject
 }

--- a/Marshal/Operators.swift
+++ b/Marshal/Operators.swift
@@ -18,27 +18,27 @@ import Foundation
 
 infix operator <| { associativity left precedence 150 }
 
-public func <| <A: ValueType>(dictionary: Object, key: String) throws -> A {
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> A {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: ValueType>(dictionary: Object, key: String) throws -> A? {
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> A? {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: ValueType>(dictionary: Object, key: String) throws -> [A] {
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> [A] {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: ValueType>(dictionary: Object, key: String) throws -> [A]? {
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> [A]? {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: Object, key: String) throws -> A {
+public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: MarshaledObject, key: String) throws -> A {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: Object, key: String) throws -> A? {
+public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: MarshaledObject, key: String) throws -> A? {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: Object, key: String) throws -> [A] {
+public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: MarshaledObject, key: String) throws -> [A] {
     return try dictionary.valueForKey(key)
 }
-public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: Object, key: String) throws -> [A]? {
+public func <| <A: RawRepresentable where A.RawValue: ValueType>(dictionary: MarshaledObject, key: String) throws -> [A]? {
     return try dictionary.valueForKey(key)
 }

--- a/Marshal/UnmarshalUpdating.swift
+++ b/Marshal/UnmarshalUpdating.swift
@@ -15,5 +15,5 @@ import Foundation
 
 
 public protocol UnmarshalUpdating {
-    func update(object object: Object)
+    func update(object object: MarshaledObject)
 }

--- a/Marshal/Unmarshaling.swift
+++ b/Marshal/Unmarshaling.swift
@@ -16,14 +16,14 @@ import Foundation
 
 public protocol Unmarshaling : ValueType {
     typealias ConvertibleType = Self
-    init(object: Object) throws
+    init(object: MarshaledObject) throws
 }
 
 extension Unmarshaling {
     
     public static func value(object: Any) throws -> ConvertibleType {
-        guard let convertedObject = object as? Object else {
-            throw Error.TypeMismatch(expected: Object.self, actual: object.dynamicType)
+        guard let convertedObject = object as? MarshaledObject else {
+            throw Error.TypeMismatch(expected: MarshaledObject.self, actual: object.dynamicType)
         }
         guard let value = try self.init(object: convertedObject) as? ConvertibleType else {
             throw Error.TypeMismatch(expected: ConvertibleType.self, actual: object.dynamicType)

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ However, addding your own extractable type is as easy as extending your type wit
 extension NSDate : ValueType {
     public static func value(object: Any) throws -> NSDate {
         guard let dateString = object as? String else {
-            throw Error.TypeMismatch(expected: String.self, actual: object.dynamicType)
+            throw Marshal.Error.TypeMismatch(expected: String.self, actual: object.dynamicType)
         }
         // assuming you have a NSDate.fromISO8601String implemented...
         guard let date = NSDate.fromISO8601String(dateString) else {
-            throw Error.TypeMismatch(expected: "ISO8601 date string", actual: dateString)
+            throw Marshal.Error.TypeMismatch(expected: "ISO8601 date string", actual: dateString)
         }
         return date
     }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In Swift, we all deal with JSON, plists, and various forms of `[String: AnyObjec
 
 ## Usage
 
-Extracting values from `[String: AnyObject]` (a.k.a. `Marshal.Object`) is as easy as:
+Extracting values from `[String: AnyObject]` (a.k.a. `MarshaledObject`) is as easy as:
 
 ```swift
 let name: String = try json.valueForKey("name")
@@ -33,15 +33,15 @@ Don't care about errors? Use `try?` to give yourself an optional value. Otherwis
 
 ## Converting to Models
 
-Often we want to take some `Marshal.Object` and turn it into one of our models (like intializing a model from a JSON object). For this, `Marshal` offers the `ObjectConvertible` protocol.
+Often we want to take some `MarshaledObject` and turn it into one of our models (like intializing a model from a JSON object). For this, `Marshal` offers the `Unmarshaling` protocol.
 
 ```swift
-struct User: ObjectConvertible {
+struct User: Unmarshaling {
     var id: String
     var name: String
     var email: String
 
-    init(object: Object) throws {
+    init(object: MarshaledObject) throws {
         id = try object.valueForKey("id")
         name = try object.valueForKey("name")
         email = try object.valueForKey("email")
@@ -57,7 +57,7 @@ let users: [User] = json.valueForKey("users")
 
 ## Add Your Own Values
 
-Out of the box, `Marshal` supports extracting native Swift types like `String`, `Int`, etc., as well as anything conforming to `ObjectConvertible`, and arrays of the aforementioned types.
+Out of the box, `Marshal` supports extracting native Swift types like `String`, `Int`, etc., as well as anything conforming to `Unmarshaling`, and arrays of the aforementioned types.
 
 However, addding your own extractable type is as easy as extending your type with `Marshal.ValueType`.
 
@@ -84,7 +84,7 @@ let birthDate: NSDate = json.valueForKey("user.dob")
 
 ## JSON
 
-One of the most common occurences of `[String: AnyObject]` are JSON objects. To this end, `Marshal` supplies a `JSONObject` typelias for `Marshal.Object`, and several helper functions.
+One of the most common occurences of `[String: AnyObject]` are JSON objects. To this end, `Marshal` supplies a `JSONObject` typelias for `MarshaledObject`, and several helper functions.
 
 ## Contributors
 


### PR DESCRIPTION
rename `Object`, get rid of array aliases.
