### PR TITLE
update `UInt64` to use `NSNumber` as the base extraction type.

### DIFF
--- a/Marshal/ValueType.swift
+++ b/Marshal/ValueType.swift
@@ -139,20 +139,10 @@ extension UInt32: ValueType {
 }
 extension UInt64: ValueType {
     public static func value(object: Any) throws -> UInt64 {
-        let is64Bit = sizeof(UInt) == sizeof(UInt64)
-        
-        if is64Bit {
-            guard let value = object as? UInt else {
-                throw Error.TypeMismatch(expected: _Value.self, actual: object.dynamicType)
-            }
-            return UInt64(value)
+        guard let value = object as? NSNumber else {
+            throw Error.TypeMismatch(expected: NSNumber.self, actual: object.dynamicType)
         }
-        else {
-            guard let value = object as? NSNumber else {
-                throw Error.TypeMismatch(expected: NSNumber.self, actual: object.dynamicType)
-            }
-            return value.unsignedLongLongValue
-        }
+        return value.unsignedLongLongValue
     }
 }
 


### PR DESCRIPTION
Since `UInt` is auto-bridged as `NSNumber`, this simplifies the extraction to use `NSNumber` by default so we don't need to do a 64bit check.
