### PR TITLE
update `UnmarshalUpdating` to allow usage on a struct.

### DIFF
--- a/Marshal/UnmarshalUpdating.swift
+++ b/Marshal/UnmarshalUpdating.swift
@@ -15,5 +15,5 @@ import Foundation
 
 
 public protocol UnmarshalUpdating {
-    func update(object object: MarshaledObject)
+    mutating func update(object object: MarshaledObject)
 }


### PR DESCRIPTION
This allows structs to use the protocol `UnmarshalUpdating` and update its properties.
