### PR TITLE
Use `valueForKeyPath` on NSDictionary for better performance.

### DIFF
--- a/MarshalTests/PerformanceTestObjects.swift
+++ b/MarshalTests/PerformanceTestObjects.swift
@@ -24,16 +24,16 @@ struct Recording : Unmarshaling {
         case Unknown
     }
     
-    let startTs:NSDate?
+    //let startTs:NSDate?
+    //let endTs:NSDate?
     let startTsStr:String
-    let endTs:NSDate?
     let status:Status
     let recordId:String
     let recGroup:RecGroup
     
     init(object json:MarshaledObject) throws {
-        startTs = try? json.valueForKey("StartTs")
-        endTs = try? json.valueForKey("EndTs")
+        //startTs = try? json.valueForKey("StartTs")
+        //endTs = try? json.valueForKey("EndTs")
         startTsStr = try json.valueForKey("StartTs")
         recordId = try json.valueForKey("RecordId")
         status = (try? json.valueForKey("Status")) ?? .Unknown
@@ -45,8 +45,8 @@ struct Program : Unmarshaling {
     
     let title:String
     let chanId:String
-    let startTime:NSDate
-    let endTime:NSDate
+    //let startTime:NSDate
+    //let endTime:NSDate
     let description:String?
     let subtitle:String?
     let recording:Recording
@@ -67,8 +67,8 @@ struct Program : Unmarshaling {
         else {
             chanId = try json.valueForKey("Channel.ChanId")
         }
-        startTime = try json.valueForKey("StartTime")
-        endTime = try json.valueForKey("EndTime")
+        //startTime = try json.valueForKey("StartTime")
+        //endTime = try json.valueForKey("EndTime")
         description = try json.valueForKey("Description")
         subtitle = try json.valueForKey("SubTitle")
         recording = try json.valueForKey("Recording")

--- a/MarshalTests/PerformanceTestObjects.swift
+++ b/MarshalTests/PerformanceTestObjects.swift
@@ -24,6 +24,7 @@ struct Recording : Unmarshaling {
         case Unknown
     }
     
+    // Date parsing is slow. Remove them so performance can focus on JSON mapping.
     //let startTs:NSDate?
     //let endTs:NSDate?
     let startTsStr:String

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -30,6 +30,35 @@ extension Dictionary: MarshaledObject {
 }
 
 extension NSDictionary: MarshaledObject {
+    public func anyForKey(key: KeyType) throws -> Any {
+        let value:Any
+        if key.dynamicType.keyTypeSeparator == "." {
+            guard let v = self.valueForKeyPath(key.stringValue) else {
+                throw Error.KeyNotFound(key: key)
+            }
+            value = v
+        }
+        else {
+            let pathComponents = key.split()
+            var accumulator: Any = self
+
+            for component in pathComponents {
+                if let componentData = accumulator as? MarshaledObject, v = componentData[component] {
+                    accumulator = v
+                    continue
+                }
+                throw Error.KeyNotFound(key: key.stringValue)
+            }
+            value = accumulator
+        }
+
+        if let _ = value as? NSNull {
+            throw Error.NullValue(key: key)
+        }
+
+        return value
+    }
+
     public subscript(key: KeyType) -> Any? {
         guard let aKey = key as? Key else { return nil }
         

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -29,6 +29,8 @@ extension Dictionary: MarshaledObject {
     }
 }
 
+extension NSDictionary: ValueType { }
+
 extension NSDictionary: MarshaledObject {
     public func anyForKey(key: KeyType) throws -> Any {
         let value:Any

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -33,6 +33,7 @@ extension NSDictionary: MarshaledObject {
     public func anyForKey(key: KeyType) throws -> Any {
         let value:Any
         if key.dynamicType.keyTypeSeparator == "." {
+            // `valueForKeyPath` is more efficient. Use it if possible.
             guard let v = self.valueForKeyPath(key.stringValue) else {
                 throw Error.KeyNotFound(key: key)
             }

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -16,6 +16,7 @@ import Foundation
 
 public protocol MarshaledObject {
     subscript(key: KeyType) -> Any? { get }
+    func anyForKey(key: KeyType) throws -> Any
 }
 
 public extension MarshaledObject {


### PR DESCRIPTION
This change results in a ~3x speedup when extracting objects from JSON if the `keyTypeSeparator` is left as the default value of `.`. 
