### PR TITLE
remove configurable key separator to improve performance

### DIFF
--- a/Sources/KeyType.swift
+++ b/Sources/KeyType.swift
@@ -15,18 +15,10 @@ import Foundation
 
 
 public protocol KeyType {
-    static var keyTypeSeparator: Character { get set }
     var stringValue: String { get }
 }
 
-public extension KeyType {
-    public func split() -> [String] {
-        return self.stringValue.characters.split(self.dynamicType.keyTypeSeparator).map(String.init)
-    }
-}
-
 extension String: KeyType {
-    public static var keyTypeSeparator: Character = "."
     public var stringValue: String {
         return self
     }

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -34,27 +34,10 @@ extension NSDictionary: ValueType { }
 extension NSDictionary: MarshaledObject {
     public func anyForKey(key: KeyType) throws -> Any {
         let value:Any
-        if key.dynamicType.keyTypeSeparator == "." {
-            // `valueForKeyPath` is more efficient. Use it if possible.
-            guard let v = self.valueForKeyPath(key.stringValue) else {
-                throw Error.KeyNotFound(key: key)
-            }
-            value = v
+        guard let v = self.valueForKeyPath(key.stringValue) else {
+            throw Error.KeyNotFound(key: key)
         }
-        else {
-            let pathComponents = key.split()
-            var accumulator: Any = self
-
-            for component in pathComponents {
-                if let componentData = accumulator as? MarshaledObject, v = componentData[component] {
-                    accumulator = v
-                    continue
-                }
-                throw Error.KeyNotFound(key: key.stringValue)
-            }
-            value = accumulator
-        }
-
+        value = v
         if let _ = value as? NSNull {
             throw Error.NullValue(key: key)
         }

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -21,7 +21,7 @@ public protocol MarshaledObject {
 
 public extension MarshaledObject {
     public func anyForKey(key: KeyType) throws -> Any {
-        let pathComponents = key.split()
+        let pathComponents = key.stringValue.characters.split(".").map(String.init)
         var accumulator: Any = self
         
         for component in pathComponents {


### PR DESCRIPTION
I was the one pushing for the configurable path separator. Unfortunately this caused a ~39% performance hit. I propose removing the configurable path separator. 
