### PR TITLE
Replaced subscript in favor of a method to avoid the ambiguous error

### DIFF
--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -22,7 +22,7 @@ public typealias MarshalDictionary = [String: AnyObject]
 // MARK: - Dictionary Extensions
 
 extension Dictionary: MarshaledObject {
-    public subscript(key: KeyType) -> Any? {
+    public func get(optionalKey key: KeyType) -> Any? {
         guard let aKey = key as? Key else { return nil }
         
         return self[aKey]
@@ -44,8 +44,8 @@ extension NSDictionary: MarshaledObject {
 
         return value
     }
-
-    public subscript(key: KeyType) -> Any? {
+    
+    public func get(optionalKey key: KeyType) -> Any? {
         guard let aKey = key as? Key else { return nil }
         
         return self[aKey]

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -15,7 +15,7 @@ import Foundation
 
 
 public protocol MarshaledObject {
-    subscript(key: KeyType) -> Any? { get }
+    func get(optionalKey key: KeyType) -> Any?
     func anyForKey(key: KeyType) throws -> Any
 }
 
@@ -25,7 +25,7 @@ public extension MarshaledObject {
         var accumulator: Any = self
         
         for component in pathComponents {
-            if let componentData = accumulator as? Self, value = componentData[component] {
+            if let componentData = accumulator as? Self, value = componentData.get(optionalKey: component) {
                 accumulator = value
                 continue
             }


### PR DESCRIPTION
This fixes an ambiguous error that was occurring when using a framework that was dependent on Marshal.
