### PR TITLE
Fix build issues for Xcode 8b4

### DIFF
--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -52,7 +52,7 @@ class MarshalTests: XCTestCase {
             let url:URL = try! self.object.valueForKey("url")
             XCTAssertEqual(url.host, "apple.com")
             
-            let expectation = self.expectation(withDescription: "error")
+            let expectation = self.expectation(description: "error")
             do {
                 let _:Int? = try self.object.valueForKey("junk")
             }
@@ -68,7 +68,7 @@ class MarshalTests: XCTestCase {
             let urls:[URL] = try! self.object.valueForKey("urls")
             XCTAssertEqual(urls.first!.host, "apple.com")
             
-            self.waitForExpectations(withTimeout: 1, handler: nil)
+            self.waitForExpectations(timeout: 1, handler: nil)
         }
     }
     
@@ -91,7 +91,7 @@ class MarshalTests: XCTestCase {
         ora = try! object <| "no key"
         XCTAssertNil(ora)
         
-        let ex = self.expectation(withDescription: "not found")
+        let ex = self.expectation(description: "not found")
         do {
             str = try object <| "not found"
         }
@@ -100,11 +100,11 @@ class MarshalTests: XCTestCase {
                 ex.fulfill()
             }
         }
-        self.waitForExpectations(withTimeout: 1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testErrors() {
-        var expectation = self.expectation(withDescription: "not found")
+        var expectation = self.expectation(description: "not found")
         let str: String = try! self.object.valueForKey("str")
         XCTAssertEqual(str, "Hello, World!")
         do {
@@ -116,7 +116,7 @@ class MarshalTests: XCTestCase {
             }
         }
         
-        expectation = self.expectation(withDescription: "key mismatch")
+        expectation = self.expectation(description: "key mismatch")
         do {
             let _:Int = try object.valueForKey("str")
         }
@@ -126,11 +126,11 @@ class MarshalTests: XCTestCase {
             }
         }
         
-        self.waitForExpectations(withTimeout: 1, handler: nil)
+        self.waitForExpectations(timeout: 1, handler: nil)
     }
     
     func testDicionary() {
-        let path = Bundle(for: self.dynamicType).pathForResource("TestDictionary", ofType: "json")!
+        let path = Bundle(for: self.dynamicType).path(forResource: "TestDictionary", ofType: "json")!
         var data = try! Data(contentsOf: URL(fileURLWithPath: path))
         var json:JSONObject = try! JSONParser.JSONObjectWithData(data)
         let url:URL = try! json.valueForKey("meta.next")
@@ -150,7 +150,7 @@ class MarshalTests: XCTestCase {
     }
     
     func testSimpleArray() {
-        let path = Bundle(for: self.dynamicType).pathForResource("TestSimpleArray", ofType: "json")!
+        let path = Bundle(for: self.dynamicType).path(forResource: "TestSimpleArray", ofType: "json")!
         var data = try! Data(contentsOf: URL(fileURLWithPath: path))
         var ra = try! JSONSerialization.jsonObject(with: data, options: []) as! [AnyObject]
         XCTAssertEqual(ra.first as? Int, 1)
@@ -163,7 +163,7 @@ class MarshalTests: XCTestCase {
     }
     
     func testObjectArray() {
-        let path = Bundle(for: self.dynamicType).pathForResource("TestObjectArray", ofType: "json")!
+        let path = Bundle(for: self.dynamicType).path(forResource: "TestObjectArray", ofType: "json")!
         var data = try! Data(contentsOf: URL(fileURLWithPath: path))
         var ra:[JSONObject] = try! JSONParser.JSONArrayWithData(data)
         
@@ -193,7 +193,7 @@ class MarshalTests: XCTestCase {
     }
     
     func testCustomObjects() {
-        let path = Bundle(for: self.dynamicType).pathForResource("People", ofType: "json")!
+        let path = Bundle(for: self.dynamicType).path(forResource: "People", ofType: "json")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))
         let obj = try! JSONParser.JSONObjectWithData(data)
         let people:[Person] = try! obj.valueForKey("people")
@@ -227,14 +227,14 @@ class MarshalTests: XCTestCase {
         let nope:MyEnum? = try! json.valueForKey("junk")
         XCTAssertEqual(nope, .none)
         
-        let expectation = self.expectation(withDescription: "enum test")
+        let expectation = self.expectation(description: "enum test")
         do {
             let _:MyEnum = try json.valueForKey("four")
         }
         catch {
             expectation.fulfill()
         }
-        waitForExpectations(withTimeout: 5, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
         
         let iOne:MyIntEnum = try! json.valueForKey("iOne")
         XCTAssertEqual(iOne, MyIntEnum.one)
@@ -243,7 +243,7 @@ class MarshalTests: XCTestCase {
     
 
     func testSet() {
-        let path = Bundle(for: self.dynamicType).pathForResource("TestSimpleSet", ofType: "json")!
+        let path = Bundle(for: self.dynamicType).path(forResource: "TestSimpleSet", ofType: "json")!
         let data = try! Data(contentsOf: URL(fileURLWithPath: path))
         let json = try! JSONSerialization.jsonObject(with: data, options: []) as! JSONObject
         

--- a/MarshalTests/PerformanceTestObjects.swift
+++ b/MarshalTests/PerformanceTestObjects.swift
@@ -81,10 +81,10 @@ struct Program : Unmarshaling {
 extension Date : ValueType {
     public static func value(_ object: Any) throws -> Date {
         guard let dateString = object as? String else {
-            throw Marshal.Error.typeMismatch(expected: String.self, actual: object.dynamicType)
+            throw Marshal.MarshalError.typeMismatch(expected: String.self, actual: object.dynamicType)
         }
         guard let date = Date.fromISO8601String(dateString) else {
-            throw Marshal.Error.typeMismatch(expected: "ISO8601 date string", actual: dateString)
+            throw Marshal.MarshalError.typeMismatch(expected: "ISO8601 date string", actual: dateString)
         }
         return date
     }

--- a/MarshalTests/PerformanceTests.swift
+++ b/MarshalTests/PerformanceTests.swift
@@ -43,7 +43,7 @@ class PerformanceTests: XCTestCase {
     }
     
     private lazy var data:Data = {
-        let path = Bundle(for: self.dynamicType).pathForResource("Large", ofType: "json")
+        let path = Bundle(for: self.dynamicType).path(forResource: "Large", ofType: "json")
         let data = try! Data(contentsOf: URL(fileURLWithPath: path!))
         return data
     }()

--- a/Sources/Error.swift
+++ b/Sources/Error.swift
@@ -14,7 +14,7 @@
 import Foundation
 
 
-public enum Error: ErrorProtocol, CustomStringConvertible {
+public enum MarshalError: Error, CustomStringConvertible {
     
     case keyNotFound(key: KeyType)
     case nullValue(key: KeyType)

--- a/Sources/JSON.swift
+++ b/Sources/JSON.swift
@@ -33,7 +33,7 @@ public struct JSONParser {
     public static func JSONArrayWithData(_ data: Data) throws -> [JSONObject] {
         let object: AnyObject = try JSONSerialization.jsonObject(with: data, options: [])
         guard let array = object as? [JSONObject] else {
-            throw Error.typeMismatch(expected: [JSONObject].self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: [JSONObject].self, actual: object.dynamicType)
         }
         return array
     }
@@ -49,7 +49,7 @@ public protocol JSONCollectionType {
 extension JSONCollectionType {
     public func jsonData() throws -> Data {
         guard let jsonCollection = self as? AnyObject else {
-            throw Error.typeMismatchWithKey(key:"", expected: AnyObject.self, actual: self.dynamicType) // shouldn't happen
+            throw MarshalError.typeMismatchWithKey(key:"", expected: AnyObject.self, actual: self.dynamicType) // shouldn't happen
         }
         return try JSONSerialization.data(withJSONObject: jsonCollection, options: [])
     }

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -37,7 +37,7 @@ extension NSDictionary: MarshaledObject {
         if key.dynamicType.keyTypeSeparator == "." {
             // `valueForKeyPath` is more efficient. Use it if possible.
             guard let v = self.value(forKeyPath: key.stringValue) else {
-                throw Error.keyNotFound(key: key)
+                throw MarshalError.keyNotFound(key: key)
             }
             value = v
         }
@@ -46,17 +46,17 @@ extension NSDictionary: MarshaledObject {
             var accumulator: Any = self
 
             for component in pathComponents {
-                if let componentData = accumulator as? MarshaledObject, v = componentData[component] {
+                if let componentData = accumulator as? MarshaledObject, let v = componentData[component] {
                     accumulator = v
                     continue
                 }
-                throw Error.keyNotFound(key: key.stringValue)
+                throw MarshalError.keyNotFound(key: key.stringValue)
             }
             value = accumulator
         }
 
         if let _ = value as? NSNull {
-            throw Error.nullValue(key: key)
+            throw MarshalError.nullValue(key: key)
         }
 
         return value

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -25,15 +25,15 @@ public extension MarshaledObject {
         var accumulator: Any = self
         
         for component in pathComponents {
-            if let componentData = accumulator as? Self, value = componentData[component] {
+            if let componentData = accumulator as? Self, let value = componentData[component] {
                 accumulator = value
                 continue
             }
-            throw Error.keyNotFound(key: key.stringValue)
+            throw MarshalError.keyNotFound(key: key.stringValue)
         }
         
         if let _ = accumulator as? NSNull {
-            throw Error.nullValue(key: key.stringValue)
+            throw MarshalError.nullValue(key: key.stringValue)
         }
         
         return accumulator
@@ -43,12 +43,12 @@ public extension MarshaledObject {
         let any = try self.anyForKey(key)
         do {
             guard let result = try A.value(any) as? A else {
-                throw Error.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: any.dynamicType)
+                throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: any.dynamicType)
             }
             return result
         }
-        catch let Error.typeMismatch(expected: expected, actual: actual) {
-            throw Error.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
+        catch let MarshalError.typeMismatch(expected: expected, actual: actual) {
+            throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
         }
     }
     
@@ -56,10 +56,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as A
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }
@@ -69,8 +69,8 @@ public extension MarshaledObject {
         do {
             return try Array<A>.value(any)
         }
-        catch let Error.typeMismatch(expected: expected, actual: actual) {
-            throw Error.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
+        catch let MarshalError.typeMismatch(expected: expected, actual: actual) {
+            throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
         }
     }
     
@@ -78,10 +78,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as [A]
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }
@@ -91,8 +91,8 @@ public extension MarshaledObject {
         do {
             return try Set<A>.value(any)
         }
-        catch let Error.typeMismatch(expected: expected, actual: actual) {
-            throw Error.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
+        catch let MarshalError.typeMismatch(expected: expected, actual: actual) {
+            throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: expected, actual: actual)
         }
     }
     
@@ -100,10 +100,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as Set<A>
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }
@@ -111,7 +111,7 @@ public extension MarshaledObject {
     public func valueForKey<A: RawRepresentable where A.RawValue: ValueType>(_ key: KeyType) throws -> A {
         let raw = try self.valueForKey(key) as A.RawValue
         guard let value = A(rawValue: raw) else {
-            throw Error.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
+            throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
         }
         return value
     }
@@ -120,10 +120,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as A
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }
@@ -132,7 +132,7 @@ public extension MarshaledObject {
         let rawArray = try self.valueForKey(key) as [A.RawValue]
         return try rawArray.map({ raw in
             guard let value = A(rawValue: raw) else {
-                throw Error.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
+                throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
             }
             return value
         })
@@ -142,10 +142,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as [A]
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }
@@ -154,7 +154,7 @@ public extension MarshaledObject {
         let rawArray = try self.valueForKey(key) as [A.RawValue]
         let enumArray: [A] = try rawArray.map({ raw in
             guard let value = A(rawValue: raw) else {
-                throw Error.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
+                throw MarshalError.typeMismatchWithKey(key: key.stringValue, expected: A.self, actual: raw)
             }
             return value
         })
@@ -165,10 +165,10 @@ public extension MarshaledObject {
         do {
             return try self.valueForKey(key) as Set<A>
         }
-        catch Error.keyNotFound {
+        catch MarshalError.keyNotFound {
             return nil
         }
-        catch Error.nullValue {
+        catch MarshalError.nullValue {
             return nil
         }
     }

--- a/Sources/UnmarshalUpdating.swift
+++ b/Sources/UnmarshalUpdating.swift
@@ -15,5 +15,5 @@ import Foundation
 
 
 public protocol UnmarshalUpdating {
-    mutating func update(object: MarshaledObject)
+    mutating func update(_ object: MarshaledObject)
 }

--- a/Sources/Unmarshaling.swift
+++ b/Sources/Unmarshaling.swift
@@ -24,10 +24,10 @@ extension Unmarshaling {
     
     public static func value(_ object: Any) throws -> ConvertibleType {
         guard let convertedObject = object as? MarshaledObject else {
-            throw Error.typeMismatch(expected: MarshaledObject.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: MarshaledObject.self, actual: object.dynamicType)
         }
         guard let value = try self.init(object: convertedObject) as? ConvertibleType else {
-            throw Error.typeMismatch(expected: ConvertibleType.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: ConvertibleType.self, actual: object.dynamicType)
         }
         return value
     }

--- a/Sources/ValueType.swift
+++ b/Sources/ValueType.swift
@@ -25,7 +25,7 @@ public protocol ValueType {
 extension ValueType {
     public static func value(_ object: Any) throws -> Value {
         guard let objectValue = object as? Value else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return objectValue
     }
@@ -43,7 +43,7 @@ extension Bool: ValueType {}
 
 extension Int64: ValueType {
     public static func value(_ object: Any) throws -> Int64 {
-        guard let value = object as? NSNumber else { throw Error.typeMismatch(expected: NSNumber.self, actual: object.dynamicType) }
+        guard let value = object as? NSNumber else { throw MarshalError.typeMismatch(expected: NSNumber.self, actual: object.dynamicType) }
         return value.int64Value
     }
 }
@@ -51,12 +51,12 @@ extension Int64: ValueType {
 extension Array where Element: ValueType {
     public static func value(_ object: Any) throws -> [Element] {
         guard let anyArray = object as? [AnyObject] else {
-            throw Error.typeMismatch(expected: self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: self, actual: object.dynamicType)
         }
         return try anyArray.map {
             let value = try Element.value($0)
             guard let element = value as? Element else {
-                throw Error.typeMismatch(expected: Element.self, actual: value.dynamicType)
+                throw MarshalError.typeMismatch(expected: Element.self, actual: value.dynamicType)
             }
             return element
         }
@@ -66,7 +66,7 @@ extension Array where Element: ValueType {
 extension Dictionary: ValueType {
     public static func value(_ object: Any) throws -> [Key: Value] {
         guard let objectValue = object as? [Key: Value] else {
-            throw Error.typeMismatch(expected: self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: self, actual: object.dynamicType)
         }
         return objectValue
     }
@@ -81,8 +81,8 @@ extension Set where Element: ValueType {
 
 extension URL: ValueType {
     public static func value(_ object: Any) throws -> URL {
-        guard let urlString = object as? String, objectValue = URL(string: urlString) else {
-            throw Error.typeMismatch(expected: self, actual: object.dynamicType)
+        guard let urlString = object as? String, let objectValue = URL(string: urlString) else {
+            throw MarshalError.typeMismatch(expected: self, actual: object.dynamicType)
         }
         return objectValue
     }
@@ -91,7 +91,7 @@ extension URL: ValueType {
 extension Int8: ValueType {
     public static func value(_ object: Any) throws -> Int8 {
         guard let value = object as? Int else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return Int8(value)
     }
@@ -99,7 +99,7 @@ extension Int8: ValueType {
 extension Int16: ValueType {
     public static func value(_ object: Any) throws -> Int16 {
         guard let value = object as? Int else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return Int16(value)
     }
@@ -107,7 +107,7 @@ extension Int16: ValueType {
 extension Int32: ValueType {
     public static func value(_ object: Any) throws -> Int32 {
         guard let value = object as? Int else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return Int32(value)
     }
@@ -116,7 +116,7 @@ extension Int32: ValueType {
 extension UInt8: ValueType {
     public static func value(_ object: Any) throws -> UInt8 {
         guard let value = object as? UInt else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return UInt8(value)
     }
@@ -124,7 +124,7 @@ extension UInt8: ValueType {
 extension UInt16: ValueType {
     public static func value(_ object: Any) throws -> UInt16 {
         guard let value = object as? UInt else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return UInt16(value)
     }
@@ -132,7 +132,7 @@ extension UInt16: ValueType {
 extension UInt32: ValueType {
     public static func value(_ object: Any) throws -> UInt32 {
         guard let value = object as? UInt else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return UInt32(value)
     }
@@ -140,7 +140,7 @@ extension UInt32: ValueType {
 extension UInt64: ValueType {
     public static func value(_ object: Any) throws -> UInt64 {
         guard let value = object as? NSNumber else {
-            throw Error.typeMismatch(expected: NSNumber.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: NSNumber.self, actual: object.dynamicType)
         }
         return value.uint64Value
     }
@@ -149,7 +149,7 @@ extension UInt64: ValueType {
 extension Character: ValueType {
     public static func value(_ object: Any) throws -> Character {
         guard let value = object as? String else {
-            throw Error.typeMismatch(expected: Value.self, actual: object.dynamicType)
+            throw MarshalError.typeMismatch(expected: Value.self, actual: object.dynamicType)
         }
         return Character(value)
     }


### PR DESCRIPTION
This mostly adds the changes suggested by the converter, and then changes `Marshal.Error` to `Marshal.MarshalError` which is annoyingly redundant, but required to avoid conflicts with the new `Error` protocol name.
