### PR TITLE
Better error for URLs

### DIFF
--- a/Sources/ValueType.swift
+++ b/Sources/ValueType.swift
@@ -81,8 +81,11 @@ extension Set where Element: ValueType {
 
 extension URL: ValueType {
     public static func value(from object: Any) throws -> URL {
-        guard let urlString = object as? String, let objectValue = URL(string: urlString) else {
-            throw MarshalError.typeMismatch(expected: self, actual: type(of: object))
+        guard let urlString = object as? String else {
+            throw MarshalError.typeMismatch(expected: String.self, actual: type(of: object))
+        }
+        guard let objectValue = URL(string: urlString) else {
+            throw MarshalError.typeMismatch(expected: "valid URL", actual: urlString)
         }
         return objectValue
     }


### PR DESCRIPTION
When trying to decode a URL, if a string does not produce a valid URL you get a TypeMismatch error saying something like "expected URL. Got __NCFString" 

This patch improves the error to indicate that the string was not a valid URL, and include the bad string in the error message. 