### PR TITLE
Only return `nil` for the same key

### DIFF
--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -56,10 +56,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as A
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -100,10 +100,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as [A]
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -122,10 +122,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as Set<A>
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -142,10 +142,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as A
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -164,10 +164,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as [A]
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -187,10 +187,10 @@ public extension MarshaledObject {
         do {
             return try self.value(for: key) as Set<A>
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }

--- a/Sources/UnmarshalingWithContext.swift
+++ b/Sources/UnmarshalingWithContext.swift
@@ -42,10 +42,10 @@ extension MarshaledObject {
             let a: A = try self.value(for: key, inContext: context)
             return a
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }
@@ -70,10 +70,10 @@ extension MarshaledObject {
         do {
             return try self.value(for: key, inContext: context) as [A]
         }
-        catch MarshalError.keyNotFound {
+        catch MarshalError.keyNotFound(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
-        catch MarshalError.nullValue {
+        catch MarshalError.nullValue(let aKey) where aKey.stringValue == key.stringValue {
             return nil
         }
     }


### PR DESCRIPTION
This is needed in order to prevent errors further down the tree from being swallowed into the `nil`.

Using `stringValue` for comparison, since `KeyType` doesn't conform to `Equatable`.