### PR TITLE
Remove Large.json from project, copy while running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,10 @@ env:
     - TVOS_SDK=appletvsimulator9.2
     - OSX_SDK=macosx10.11
   matrix:
-    - DESTINATION="OS=8.1,name=iPhone 4S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
-    - DESTINATION="OS=8.2,name=iPhone 5"        SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
-    - DESTINATION="OS=8.3,name=iPhone 5S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
-    - DESTINATION="OS=8.4,name=iPad Air"        SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=9.0,name=iPhone 6S Plus"  SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=9.1,name=iPhone 6S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=9.3,name=iPad Pro"        SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=10.0,name=iPhone 7"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
-    - DESTINATION="arch=x86_64"                 SCHEME="$FRAMEWORK_SCHEME" SDK="$OSX_SDK"
 
 before_install:
   - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/Marshal.xcodeproj/project.pbxproj
+++ b/Marshal.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		7112BA9D1C7ECD5600B657F9 /* TestObjectArray.json in Resources */ = {isa = PBXBuildFile; fileRef = 7112BA991C7ECD5600B657F9 /* TestObjectArray.json */; };
 		7112BA9E1C7ECD5600B657F9 /* TestSimpleArray.json in Resources */ = {isa = PBXBuildFile; fileRef = 7112BA9A1C7ECD5600B657F9 /* TestSimpleArray.json */; };
 		71EFC3A81CCB4EAF00394E57 /* PerformanceTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EFC3A71CCB4EAF00394E57 /* PerformanceTestObjects.swift */; };
-		71EFC3AA1CCB505C00394E57 /* Large.json in Resources */ = {isa = PBXBuildFile; fileRef = 71EFC3A91CCB505C00394E57 /* Large.json */; };
 		71EFC3AC1CCB513300394E57 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EFC3AB1CCB513300394E57 /* PerformanceTests.swift */; };
 		AE5720E71C7FE97E00D45DE3 /* TestSimpleSet.json in Resources */ = {isa = PBXBuildFile; fileRef = AE5720E61C7FE97E00D45DE3 /* TestSimpleSet.json */; };
 		AECB67181CD317CA00141059 /* MarshalDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB67171CD317CA00141059 /* MarshalDictionary.swift */; };
@@ -51,7 +50,6 @@
 		7112BA991C7ECD5600B657F9 /* TestObjectArray.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestObjectArray.json; sourceTree = "<group>"; };
 		7112BA9A1C7ECD5600B657F9 /* TestSimpleArray.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestSimpleArray.json; sourceTree = "<group>"; };
 		71EFC3A71CCB4EAF00394E57 /* PerformanceTestObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTestObjects.swift; sourceTree = "<group>"; };
-		71EFC3A91CCB505C00394E57 /* Large.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Large.json; sourceTree = "<group>"; };
 		71EFC3AB1CCB513300394E57 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		AE5720E61C7FE97E00D45DE3 /* TestSimpleSet.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestSimpleSet.json; sourceTree = "<group>"; };
 		AECB67171CD317CA00141059 /* MarshalDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarshalDictionary.swift; path = Sources/MarshalDictionary.swift; sourceTree = SOURCE_ROOT; };
@@ -136,7 +134,6 @@
 		AFBED25D1C7E1AAB00622331 /* MarshalTests */ = {
 			isa = PBXGroup;
 			children = (
-				71EFC3A91CCB505C00394E57 /* Large.json */,
 				7112BA971C7ECD5600B657F9 /* People.json */,
 				7112BA981C7ECD5600B657F9 /* TestDictionary.json */,
 				7112BA991C7ECD5600B657F9 /* TestObjectArray.json */,
@@ -191,6 +188,7 @@
 				AFBED2551C7E1AAB00622331 /* Sources */,
 				AFBED2561C7E1AAB00622331 /* Frameworks */,
 				AFBED2571C7E1AAB00622331 /* Resources */,
+				CC9E2E531DEF838800A4A353 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -254,7 +252,6 @@
 			files = (
 				7112BA9B1C7ECD5600B657F9 /* People.json in Resources */,
 				AE5720E71C7FE97E00D45DE3 /* TestSimpleSet.json in Resources */,
-				71EFC3AA1CCB505C00394E57 /* Large.json in Resources */,
 				7112BA9E1C7ECD5600B657F9 /* TestSimpleArray.json in Resources */,
 				459FC6BD1DC28F0000BD9DAC /* TestMissingData.json in Resources */,
 				7112BA9C1C7ECD5600B657F9 /* TestDictionary.json in Resources */,
@@ -263,6 +260,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		CC9E2E531DEF838800A4A353 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "CONTENTS_PATH=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}\"\ncp $PROJECT_DIR/MarshalTests/Large.json $CONTENTS_PATH/";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		AFBED24A1C7E1AAB00622331 /* Sources */ = {

--- a/Marshal.xcodeproj/project.pbxproj
+++ b/Marshal.xcodeproj/project.pbxproj
@@ -273,7 +273,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "CONTENTS_PATH=\"${TARGET_BUILD_DIR}/${CONTENTS_FOLDER_PATH}\"\ncp $PROJECT_DIR/MarshalTests/Large.json $CONTENTS_PATH/";
+			shellScript = "CONTENTS_PATH=\"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}\"\ncp $PROJECT_DIR/MarshalTests/Large.json $CONTENTS_PATH/";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -349,8 +349,8 @@ class MarshalTests: XCTestCase {
             "missing": NSNull(),
             "small": 2,
             "medium": 66_000,
-            "large": largeNum,
-            "huge": hugeNum,
+            "large": NSNumber(value: largeNum), // github tests fail otherwise
+            "huge": NSNumber(value: hugeNum), // github tests fail otherwise
             "decimal": 1.2,
             "array": [ "a", "b", "c" ],
             "nested": [

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -340,14 +340,17 @@ class MarshalTests: XCTestCase {
     }
 
     func testMarshalingSwiftValues() {
+
+        let largeNum: Int64 = 4_200_000_000
+        let hugeNum: UInt64 = 9_000_000_000_000_000_000
         let object: MarshalDictionary = [
             "string": "A String",
             "truth": true,
             "missing": NSNull(),
             "small": 2,
             "medium": 66_000,
-            "large": 4_200_000_000,
-            "huge": 9_000_000_000_000_000_000,
+            "large": largeNum,
+            "huge": hugeNum,
             "decimal": 1.2,
             "array": [ "a", "b", "c" ],
             "nested": [
@@ -362,8 +365,8 @@ class MarshalTests: XCTestCase {
             let missing: String? = try result <| "missing"
             let small: Int = try result <| "small"
             let medium: Int = try result <| "medium"
-            let large: Int = try result <| "large"
-            let huge: Int = try result <| "huge"
+            let large: Int64 = try result <| "large"
+            let huge: UInt64 = try result <| "huge"
             let decimal: Float = try result <| "decimal"
             let array: [String] = try result <| "array"
             let nested: [String:Any] = try result <| "nested"
@@ -373,8 +376,8 @@ class MarshalTests: XCTestCase {
             XCTAssertNil(missing)
             XCTAssertEqual(small, 2)
             XCTAssertEqual(medium, 66_000)
-            XCTAssertEqual(large, 4_200_000_000)
-            XCTAssertEqual(huge, 9_000_000_000_000_000_000)
+            XCTAssertEqual(large, largeNum)
+            XCTAssertEqual(huge, hugeNum)
             XCTAssertEqual(decimal, 1.2)
             XCTAssertEqual(array, [ "a", "b", "c" ])
             XCTAssertEqual(nested as! [String:String], [ "key": "value" ])


### PR DESCRIPTION
The file Large.json causes projects which use Marshal to slow down Xcode while searching for strings. 

This patch removes Large.json from the project and adds a build phase to copy it so that it is available for the performance test. 