### PR TITLE
Fix regression unmarshalling optional subdictionaries

### DIFF
--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -160,6 +160,31 @@ class MarshalTests: XCTestCase {
         XCTAssertEqual(result["ok"], true)
     }
     
+    func testOptionalDictionary() {
+        let jsonObject: JSONObject = ["not a dictionary": ["strings", "strings and", "more strings"], "also not a dictionary": 12]
+        
+        do {
+            let optSubObject: JSONObject? = try jsonObject.value(for: "whatevs")
+            XCTAssertNil(optSubObject)
+        } catch {
+            XCTFail()
+        }
+        
+        let expectation = self.expectation(description: "type mismatch")
+        do {
+            let totesNotADict: JSONObject? = try jsonObject.value(for: "not a dictionary")
+            XCTFail("what are you? \(totesNotADict)")
+            
+            let alsoNotADictionary: JSONObject? = try jsonObject.value(for: "also not a dictionary")
+            XCTFail("what are you? \(alsoNotADictionary)")
+        } catch {
+            if case MarshalError.typeMismatchWithKey = error {
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+    
     func testSimpleArray() {
         let path = Bundle(for: type(of: self)).path(forResource: "TestSimpleArray", ofType: "json")!
         var data = try! Data(contentsOf: URL(fileURLWithPath: path))

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -148,8 +148,7 @@ public extension MarshaledObject {
     
     public func value(for key: KeyType) throws -> MarshalDictionary? {
         do {
-            let forReals: MarshalDictionary = try value(for: key)
-            return forReals
+            return try value(for: key) as MarshalDictionary
         }
         catch MarshalError.keyNotFound {
             return nil

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -145,6 +145,19 @@ public extension MarshaledObject {
         }
         return object
     }
+    
+    public func value(for key: KeyType) throws -> MarshalDictionary? {
+        do {
+            let forReals: MarshalDictionary = try value(for: key)
+            return forReals
+        }
+        catch MarshalError.keyNotFound {
+            return nil
+        }
+        catch MarshalError.nullValue {
+            return nil
+        }
+    }
 
     public func value<A: ValueType>(for key: KeyType) throws -> Set<A> {
         let any = try self.any(for: key)


### PR DESCRIPTION
prevent throwing of `MarshalError` for optional dictionaries. e.g.

    let opt: JSONObject? = try json <| "optional_property"

add unit tests to guard against future regressions and verify behavior