### PR TITLE
Bug fix operator expansion

### DIFF
--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -161,7 +161,7 @@ class MarshalTests: XCTestCase {
         do {
             // Check the optional getter
             result = try json.value(for: "result") ?? [:]
-            XCTAssertNotNil(result)
+            result = try json.value(for: "emptyKey") ?? [:]
         }
         catch {
             XCTFail()

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -155,9 +155,17 @@ class MarshalTests: XCTestCase {
         let dead = try! !person.value(for: "living")
         XCTAssertTrue(dead)
 
-        let result: [String: Bool] = try! json.value(for: "result")
+        var result: [String: Bool] = try! json.value(for: "result")
         XCTAssertEqual(result.count, 1)
         XCTAssertEqual(result["ok"], true)
+        do {
+            // Check the optional getter
+            result = try json.value(for: "result") ?? [:]
+            XCTAssertNotNil(result)
+        }
+        catch {
+            XCTFail()
+        }
     }
     
     func testOptionalDictionary() {

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -398,6 +398,7 @@ class MarshalTests: XCTestCase {
             "huge": Int.max,
             "decimal": 1.2,
             "array": [ "a", "b", "c" ],
+            "boolDictionary": [ "a": true, "b": false, "c": true ],
             "nested": [
                 "key": "value"
             ]
@@ -414,6 +415,8 @@ class MarshalTests: XCTestCase {
             let huge: Int = try result <| "huge"
             let decimal: Float = try result <| "decimal"
             let array: [String] = try result <| "array"
+            let boolDictionary: [String: Bool] = try result <| "boolDictionary"
+            let optBoolDictionary: [String: Bool]? = try result <| "boolDictionary"
             let nested: [String:Any] = try result <| "nested"
 
             XCTAssertEqual(string, "A String")
@@ -426,6 +429,8 @@ class MarshalTests: XCTestCase {
             XCTAssertEqual(decimal, 1.2)
             XCTAssertEqual(array, [ "a", "b", "c" ])
             XCTAssertEqual(nested as! [String:String], [ "key": "value" ])
+            XCTAssertEqual(boolDictionary, [ "a": true, "b": false, "c": true ])
+            XCTAssertEqual(boolDictionary, optBoolDictionary ?? [:])
         } catch {
             XCTFail("Error converting MarshalDictionary: \(error)")
         }

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -119,8 +119,8 @@ public extension MarshaledObject {
     }
 
     public func value<A: ValueType>(for key: KeyType) throws -> [String: A]? {
-        let any = try self.any(for: key)
         do {
+            let any = try self.any(for: key)
             return try [String: A].value(from: any)
         }
         catch MarshalError.keyNotFound {

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -119,6 +119,7 @@ public extension MarshaledObject {
     }
 
     public func value<A: ValueType>(for key: KeyType) throws -> [String: A]? {
+        let any = try self.any(for: key)
         do {
             return try [String: A].value(from: any)
         }

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -52,3 +52,6 @@ public func <| (dictionary: MarshaledObject, key: String) throws -> JSONObject {
 public func <| (dictionary: MarshaledObject, key: String) throws -> [JSONObject] {
     return try dictionary.value(for: key)
 }
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> [String: A] {
+    return try dictionary.value(for: key)
+}

--- a/Sources/Operators.swift
+++ b/Sources/Operators.swift
@@ -55,3 +55,6 @@ public func <| (dictionary: MarshaledObject, key: String) throws -> [JSONObject]
 public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> [String: A] {
     return try dictionary.value(for: key)
 }
+public func <| <A: ValueType>(dictionary: MarshaledObject, key: String) throws -> [String: A]? {
+    return try dictionary.value(for: key)
+}


### PR DESCRIPTION
Hey @jarsen -- this PR may fix #54. It also fixes a scary bug where I thought the function had a local variable `any`, but it resolved as the function as type `Any`, which then fails to cast into anything useful. Oops.

I added some tests so this shouldn't regress.