### PR TITLE
Adds 3 and 4 (tv and watch) to TARGETED_DEVICE_FAMILY

### DIFF
--- a/Marshal.xcodeproj/project.pbxproj
+++ b/Marshal.xcodeproj/project.pbxproj
@@ -355,7 +355,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchsimulator watchos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386 armv7k";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -401,7 +401,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvsimulator appletvos watchsimulator watchos";
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,3,4";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
 				VALID_ARCHS = "arm64 armv7 armv7s x86_64 i386 armv7k";


### PR DESCRIPTION
Fixes issue where tv and watch simulators could cause build failures when building with Carthage

This is in use with other frameworks, [PromiseKit](https://github.com/mxcl/PromiseKit) being an example with a reasonable following.