### PR TITLE
Adding marshaled() to Array<Marshaling>

### DIFF
--- a/Sources/Marshaling.swift
+++ b/Sources/Marshaling.swift
@@ -18,3 +18,9 @@ public protocol Marshaling {
     
     func marshaled() -> Self.MarshalType
 }
+
+extension Array where Element: Marshaling {
+    public func marshaled() -> [Any] {
+        return self.map { $0.marshaled() }
+    }
+}


### PR DESCRIPTION
Hey!  Thanks for writing Marshal.

Consider these nested types:

```swift
struct Person {
    let name: String
}

struct Group {
    let name: String
    let members: [Person]
}
```

I'm guessing the implementation of `Marshaling` on `Group.members` would look like this?

```swift
extension Person: Marshaling {
    func marshaled() -> [String: Any] {
        return ["name": self.name]
    }
}

extension Group: Marshaling {
    func marshaled() -> [String: Any] {
        return [
            "name": name,
            "members": self.members.map { $0.marshaled() }
        ]
    }
}
```

Is that the expected way to do that, or did I miss something obvious?

This PR adds `Marshaling` on `Array<Marshaling`>, so that you can do this instead:

```swift
extension Group: Marshaling {
    func marshaled() -> [String: Any] {
        return [
            "name": name,
            "members": self.members.marshaled()
        ]
    }
}
```
