### PR TITLE
Support coding keys

### DIFF
--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -136,7 +136,7 @@ class MarshalTests: XCTestCase {
         self.waitForExpectations(timeout: 1, handler: nil)
     }
     
-    func testDicionary() {
+    func testDictionary() {
         let path = Bundle(for: type(of: self)).path(forResource: "TestDictionary", ofType: "json")!
         var data = try! Data(contentsOf: URL(fileURLWithPath: path))
         var json: JSONObject = try! JSONParser.JSONObjectWithData(data)
@@ -291,6 +291,40 @@ class MarshalTests: XCTestCase {
         
         waitForExpectations(timeout: 1, handler: nil)
     }
+    
+    func testCustomObjectsCodable() {
+        let path = Bundle(for: type(of: self)).path(forResource: "People", ofType: "json")!
+        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        let obj = try! JSONParser.JSONObjectWithData(data)
+        let people: [PersonCodable] = try! obj.value(for: "people")
+        let person: PersonCodable = try! obj.value(for: "person")
+        XCTAssertEqual(people.first!.firstName, "Jason")
+        XCTAssertEqual(person.firstName, "Jason")
+        XCTAssertEqual(person.score, 42)
+        XCTAssertEqual(people.last!.address!.city, "Cupertino")
+        
+        let expectation1 = expectation(description: "error test")
+        do {
+            let _:AgedPersonCodable = try obj.value(for: "person")
+        }
+        catch {
+            if case MarshalError.keyNotFound = error {
+                expectation1.fulfill()
+            }
+        }
+        
+        let expectation2 = expectation(description: "array error test")
+        do {
+            let _:[AgedPersonCodable] = try obj.value(for: "people")
+        }
+        catch {
+            if case MarshalError.keyNotFound = error {
+                expectation2.fulfill()
+            }
+        }
+        
+        waitForExpectations(timeout: 1, handler: nil)
+    }
 
     func testContainedCustomObjects() {
         let path = Bundle(for: type(of: self)).path(forResource: "PeopleByKey", ofType: "json")!
@@ -343,7 +377,6 @@ class MarshalTests: XCTestCase {
         let iOne: MyIntEnum = try! json.value(for: "iOne")
         XCTAssertEqual(iOne, MyIntEnum.one)
     }
-    
 
     func testSet() {
         let path = Bundle(for: type(of: self)).path(forResource: "TestSimpleSet", ofType: "json")!
@@ -512,6 +545,15 @@ private struct Address: Unmarshaling {
     }
 }
 
+private struct AddressCodable: Unmarshaling, Codable {
+    let street:String
+    let city:String
+    init(object json: MarshaledObject) throws {
+        street = try json.value(for: CodingKeys.street)
+        city = try json.value(for: CodingKeys.city)
+    }
+}
+
 private struct Person: Unmarshaling {
     let firstName:String
     let lastName:String
@@ -526,10 +568,38 @@ private struct Person: Unmarshaling {
     }
 }
 
+private struct PersonCodable: Unmarshaling, Codable {
+    enum CodingKeys: String, CodingKey {
+        case firstName = "first"
+        case lastName = "last"
+        case score
+        case address
+    }
+    
+    let firstName:String
+    let lastName:String
+    let score:Int
+    let address:AddressCodable?
+    
+    init(object json: MarshaledObject) throws {
+        firstName = try json.value(for: CodingKeys.firstName)
+        lastName = try json.value(for: CodingKeys.lastName)
+        score = try json.value(for: CodingKeys.score)
+        address = try json.value(for: CodingKeys.address)
+    }
+}
+
 private struct AgedPerson: Unmarshaling {
     var age:Int = 0
     init(object: MarshaledObject) throws {
         age = try object.value(for: "age")
+    }
+}
+
+private struct AgedPersonCodable: Unmarshaling, Codable {
+    var age:Int = 0
+    init(object: MarshaledObject) throws {
+        age = try object.value(for: CodingKeys.age)
     }
 }
 

--- a/Sources/KeyType.swift
+++ b/Sources/KeyType.swift
@@ -14,12 +14,17 @@
 import Foundation
 
 
-public protocol KeyType {
-    var stringValue: String { get }
-}
+public typealias KeyType = CodingKey
 
-extension String: KeyType {
-    public var stringValue: String {
-        return self
+extension String: CodingKey {
+    public var stringValue: String { return self }
+    public var intValue: Int? { return nil }
+    
+    public init?(stringValue: String) {
+        self = String(stringValue)
+    }
+    
+    public init?(intValue: Int) {
+        return nil
     }
 }


### PR DESCRIPTION
Hello,

I love using Marshal as it is much simpler than swift's `Codable`. But very often I want to serialize and deserialize my objects using the same keys. So I was always creating enums so the keys are kept on a single place. 

And I was wondering why I need to write that when conforming to `Codable` does that for me automatically. So i thought it would be nice if Marshal supported using `CodingKeys`.

I had two ideas
1. add variants of `value(for:)` methods with `CodingKey` variant
2. substitute `KeyType` for `CodingKey`

I went for variant 2 as it made more sense for me. At first I wanted to say that every `CodingKey` is also a `KeyType` as `KeyType` requires just a `stringValue` which is a subset of what `CodingKey` requires. This was no way as the compiler doesn't allow protocol inheritace in this way.

Well then I removed custom `KeyType` and converted it to `CodingKey`.