### PR TITLE
Add possibility to use indexes for array objects nested by keypath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8
+osx_image: xcode10
 
 env:
   global:
@@ -12,6 +12,7 @@ env:
     - TVOS_SDK=appletvsimulator9.2
     - OSX_SDK=macosx10.11
   matrix:
+    - DESTINATION="OS=8.0,name=iPhone 4S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=8.1,name=iPhone 4S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=8.2,name=iPhone 5"        SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=8.3,name=iPhone 5S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
@@ -20,6 +21,8 @@ env:
     - DESTINATION="OS=9.1,name=iPhone 6S"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=9.3,name=iPad Pro"        SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="OS=10.0,name=iPhone 7"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
+    - DESTINATION="OS=11.0,name=iPhone X"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
+    - DESTINATION="OS=12.0,name=iPhone X"       SCHEME="$FRAMEWORK_SCHEME" SDK="$IOS_SDK"
     - DESTINATION="arch=x86_64"                 SCHEME="$FRAMEWORK_SCHEME" SDK="$OSX_SDK"
 
 before_install:

--- a/Marshal.xcodeproj/project.pbxproj
+++ b/Marshal.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		71EFC3A81CCB4EAF00394E57 /* PerformanceTestObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EFC3A71CCB4EAF00394E57 /* PerformanceTestObjects.swift */; };
 		71EFC3AA1CCB505C00394E57 /* Large.json in Resources */ = {isa = PBXBuildFile; fileRef = 71EFC3A91CCB505C00394E57 /* Large.json */; };
 		71EFC3AC1CCB513300394E57 /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71EFC3AB1CCB513300394E57 /* PerformanceTests.swift */; };
+		7992303021DE67C400A0D8A8 /* MarshalArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7992302F21DE67C300A0D8A8 /* MarshalArray.swift */; };
 		ABEFEBDB1DF4BFEA00D6D6CD /* PeopleByKey.json in Resources */ = {isa = PBXBuildFile; fileRef = ABEFEBDA1DF4BFEA00D6D6CD /* PeopleByKey.json */; };
 		AE5720E71C7FE97E00D45DE3 /* TestSimpleSet.json in Resources */ = {isa = PBXBuildFile; fileRef = AE5720E61C7FE97E00D45DE3 /* TestSimpleSet.json */; };
 		AECB67181CD317CA00141059 /* MarshalDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECB67171CD317CA00141059 /* MarshalDictionary.swift */; };
@@ -55,6 +56,7 @@
 		71EFC3A71CCB4EAF00394E57 /* PerformanceTestObjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTestObjects.swift; sourceTree = "<group>"; };
 		71EFC3A91CCB505C00394E57 /* Large.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Large.json; sourceTree = "<group>"; };
 		71EFC3AB1CCB513300394E57 /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
+		7992302F21DE67C300A0D8A8 /* MarshalArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarshalArray.swift; path = Sources/MarshalArray.swift; sourceTree = SOURCE_ROOT; };
 		ABEFEBDA1DF4BFEA00D6D6CD /* PeopleByKey.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = PeopleByKey.json; sourceTree = "<group>"; };
 		AE5720E61C7FE97E00D45DE3 /* TestSimpleSet.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestSimpleSet.json; sourceTree = "<group>"; };
 		AECB67171CD317CA00141059 /* MarshalDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MarshalDictionary.swift; path = Sources/MarshalDictionary.swift; sourceTree = SOURCE_ROOT; };
@@ -123,6 +125,7 @@
 				AFBED2521C7E1AAB00622331 /* Marshal.h */,
 				AFBED2541C7E1AAB00622331 /* Info.plist */,
 				AFBED2691C7E1B0500622331 /* MarshaledObject.swift */,
+				7992302F21DE67C300A0D8A8 /* MarshalArray.swift */,
 				AECB67171CD317CA00141059 /* MarshalDictionary.swift */,
 				AFBED2711C7E1DA800622331 /* Marshaling.swift */,
 				AFBED27B1C7F65BB00622331 /* Unmarshaling.swift */,
@@ -287,6 +290,7 @@
 				AFBED26E1C7E1CA900622331 /* ValueType.swift in Sources */,
 				AFBED26A1C7E1B0500622331 /* MarshaledObject.swift in Sources */,
 				CC7504601DA6B27500643B7A /* Migration.swift in Sources */,
+				7992303021DE67C400A0D8A8 /* MarshalArray.swift in Sources */,
 				AFBED26C1C7E1B3500622331 /* KeyType.swift in Sources */,
 				CCAE549F1CFDF9D30069AC65 /* UnmarshalingWithContext.swift in Sources */,
 				AFBED2741C7E1E0800622331 /* Operators.swift in Sources */,

--- a/Sources/KeyType.swift
+++ b/Sources/KeyType.swift
@@ -16,10 +16,14 @@ import Foundation
 
 public protocol KeyType {
     var stringValue: String { get }
+    var intValue: Int? { get }
 }
 
 extension String: KeyType {
     public var stringValue: String {
         return self
+    }
+    public var intValue: Int? {
+        return Int(self)
     }
 }

--- a/Sources/MarshalArray.swift
+++ b/Sources/MarshalArray.swift
@@ -1,0 +1,20 @@
+//
+//  M A R S H A L
+//
+//       ()
+//       /\
+//  ()--'  '--()
+//    `.    .'
+//     / .. \
+//    ()'  '()
+//
+//
+
+import Foundation
+
+extension Array: MarshaledObject {
+    public func optionalAny(for key: KeyType) -> Any? {
+        guard let index = key.intValue else { return nil }
+        return indices ~= index ? self[index] : nil
+    }
+}

--- a/Sources/MarshalDictionary.swift
+++ b/Sources/MarshalDictionary.swift
@@ -41,6 +41,9 @@ extension NSDictionary: ValueType { }
 
 extension NSDictionary: MarshaledObject {
     public func any(for key: KeyType) throws -> Any {
+        if let value = self.object(forKey: key.stringValue) {
+            return value
+        }
         guard let value: Any = self.value(forKeyPath: key.stringValue) else {
             throw MarshalError.keyNotFound(key: key)
         }

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -48,7 +48,10 @@ public extension MarshaledObject {
         var accumulator: Any = self
     
         for component in finalComponents {
-            if let componentData = accumulator as? Self, let value = componentData.optionalAny(for: component) {
+            if let componentData = accumulator as? [Any], let value = componentData.optionalAny(for: component) {
+                accumulator = value
+                continue
+            } else if let componentData = accumulator as? Self, let value = componentData.optionalAny(for: component) {
                 accumulator = value
                 continue
             }


### PR DESCRIPTION
This PR adds a new feature of getting the object at a particular index by keyPath.
Let's say that we have JSON like this:

```
{
   "id": 5393,
   "title": "",
   "content": "",
   "categories": [
       {
          "id": 321
          "name": "Main Category"
       }, {
          "id": 321
          "name": "Child Category"
       },
   ]
}
```

Right now is not possible to parse just first object from category array. After my change you can use index in keypath like this:
`category = try object.value(for: "categories.0")`
this will take a look inside array if object at key `categories` is array if not it will raise exception or follow keyPath as string value of `0`.