### PR TITLE
Allow escaping periods in a key path by preceding them with a double backslash

### DIFF
--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -22,6 +22,7 @@ class MarshalTests: XCTestCase {
                                      "object": ["foo": 3, "str": "Hello, World!"],
                                      "url": "http://apple.com",
                                      "junk": "garbage",
+                                     "dict": [ "one" : 1, "sub.dict" : [ "two" : 2 ] ],
                                      "urls": ["http://apple.com", "http://github.com"]]
     
     override func setUp() {
@@ -37,6 +38,10 @@ class MarshalTests: XCTestCase {
     
     func testBasics() {
         self.measure {
+        	let one: Int = try! self.object.value(for: "dict.one")
+            XCTAssertEqual(one, 1)
+        	let two: Int = try! self.object.value(for: "dict.sub\\.dict.two")
+            XCTAssertEqual(two, 2)
             let str: String = try! self.object.value(for: "str")
             XCTAssertEqual(str, "Hello, World!")
             //    var foo1: String = try object.value(for: "foo")

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -23,6 +23,7 @@ class MarshalTests: XCTestCase {
                                      "url": "http://apple.com",
                                      "junk": "garbage",
                                      "dict": [ "one" : 1, "sub.dict" : [ "two" : 2 ] ],
+                                     "val.two" : 2,
                                      "urls": ["http://apple.com", "http://github.com"]]
     
     override func setUp() {
@@ -40,6 +41,8 @@ class MarshalTests: XCTestCase {
         self.measure {
         	let one: Int = try! self.object.value(for: "dict.one")
             XCTAssertEqual(one, 1)
+        	let valTwo: Int = try! self.object.value(for: "val\\.two")
+            XCTAssertEqual(valTwo, 2)
         	let two: Int = try! self.object.value(for: "dict.sub\\.dict.two")
             XCTAssertEqual(two, 2)
             let str: String = try! self.object.value(for: "str")

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -39,7 +39,7 @@ class MarshalTests: XCTestCase {
     
     func testBasics() {
         self.measure {
-        	let one: Int = try! self.object.value(for: "dict.one")
+            let one: Int = try! self.object.value(for: "dict.one")
             XCTAssertEqual(one, 1)
         	let valTwo: Int = try! self.object.value(for: "val\\.two")
             XCTAssertEqual(valTwo, 2)

--- a/MarshalTests/MarshalTests.swift
+++ b/MarshalTests/MarshalTests.swift
@@ -41,9 +41,9 @@ class MarshalTests: XCTestCase {
         self.measure {
             let one: Int = try! self.object.value(for: "dict.one")
             XCTAssertEqual(one, 1)
-        	let valTwo: Int = try! self.object.value(for: "val\\.two")
+            let valTwo: Int = try! self.object.value(for: "val\\.two")
             XCTAssertEqual(valTwo, 2)
-        	let two: Int = try! self.object.value(for: "dict.sub\\.dict.two")
+            let two: Int = try! self.object.value(for: "dict.sub\\.dict.two")
             XCTAssertEqual(two, 2)
             let str: String = try! self.object.value(for: "str")
             XCTAssertEqual(str, "Hello, World!")

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -22,31 +22,31 @@ public protocol MarshaledObject {
 public extension MarshaledObject {
     public func any(for key: KeyType) throws -> Any {
         let pathComponents = key.stringValue.split(separator: ".").map(String.init)
-	
-        //	Re-combine components ending in backslash…
-	
-		var finalComponents = [String]()
-		var comp = ""
-		for component in pathComponents {
-			if component.hasSuffix("\\") {
-				let c = String(component.dropLast())
-				if comp.count > 0 {
-					comp += "."
-				}
-				comp += c
-			} else {
-				if comp.count > 0 {
-					comp += "." + component
-					finalComponents.append(comp)
-					comp = ""
-				} else {
-					finalComponents.append(component)
-				}
-			}
-		}
-	
+    
+        //  Re-combine components ending in backslash…
+    
+        var finalComponents = [String]()
+        var comp = ""
+        for component in pathComponents {
+            if component.hasSuffix("\\") {
+                let c = String(component.dropLast())
+                if comp.count > 0 {
+                    comp += "."
+                }
+                comp += c
+            } else {
+                if comp.count > 0 {
+                    comp += "." + component
+                    finalComponents.append(comp)
+                    comp = ""
+                } else {
+                    finalComponents.append(component)
+                }
+            }
+        }
+    
         var accumulator: Any = self
-	
+    
         for component in finalComponents {
             if let componentData = accumulator as? Self, let value = componentData.optionalAny(for: component) {
                 accumulator = value

--- a/Sources/MarshaledObject.swift
+++ b/Sources/MarshaledObject.swift
@@ -22,9 +22,32 @@ public protocol MarshaledObject {
 public extension MarshaledObject {
     public func any(for key: KeyType) throws -> Any {
         let pathComponents = key.stringValue.split(separator: ".").map(String.init)
+	
+        //	Re-combine components ending in backslash…
+	
+		var finalComponents = [String]()
+		var comp = ""
+		for component in pathComponents {
+			if component.hasSuffix("\\") {
+				let c = String(component.dropLast())
+				if comp.count > 0 {
+					comp += "."
+				}
+				comp += c
+			} else {
+				if comp.count > 0 {
+					comp += "." + component
+					finalComponents.append(comp)
+					comp = ""
+				} else {
+					finalComponents.append(component)
+				}
+			}
+		}
+	
         var accumulator: Any = self
-        
-        for component in pathComponents {
+	
+        for component in finalComponents {
             if let componentData = accumulator as? Self, let value = componentData.optionalAny(for: component) {
                 accumulator = value
                 continue


### PR DESCRIPTION
The code first splits on period, as in the original, then it checks to see if any components ends in a backslash, and re-combines them into a key.