### PR TITLE
Add support for swift-tools-version:4.0

### DIFF
--- a/Marshal.podspec
+++ b/Marshal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name						= "Marshal"
-  s.version						= "1.2.7"
+  s.version						= "1.2.8"
   s.summary						= "Marshal is a simple, lightweight framework for safely extracting values from [String: AnyObject]"
   s.description					= <<-DESC
                    					In Swift, we all deal with JSON, plists, and various forms of [String: Any]. Marshal believes you don't need a Ph.D. in monads or magic mirrors to deal with these in an expressive and type safe way. Marshal will help you write declarative, performant, error handled code using the power of Protocol Oriented Programming™.

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,17 @@
+// swift-tools-version:4.0
+import PackageDescription
+
+let package = Package(
+    name: "Marshal",
+    products: [
+        .library(name: "Marshal", targets: ["Marshal"]),
+    ],
+    targets: [
+        .target(
+            name: "Marshal",
+	    dependencies: [],
+	    path: "Sources"
+        )
+    ]
+)
+


### PR DESCRIPTION
I ran into some issues using SPM version 5.0. It complained about unresolvable dependencies, but really the issue seemed to be that the `Package.swift` needed to be updated. I updated it to swift-tools-version:4.0 (so it should work with both SPM 4.x.x and 5.x.x -- I only tested with 5.0.0). 

To keep things consistent I bumped the version in the podspec and tagged the whole shebang as 1.2.8 and everything seems to work fine now.

I hope this is useful to you!